### PR TITLE
feat: Added link to OP.GG

### DIFF
--- a/app/components/image-grid.tsx
+++ b/app/components/image-grid.tsx
@@ -186,6 +186,15 @@ export function ImageGrid({ images, displayImages = images }: ImageGridProps) {
 									>
 										metasrc
 									</a>
+									<a
+										href={`https://op.gg/lol/modes/arena/${image.name.toLowerCase()}/build`}
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={(e) => e.stopPropagation()}
+										className="px-2 py-0.5 text-xs font-medium bg-blue-500/90 text-white rounded-full hover:bg-blue-600 transition-colors shadow-sm ring-1 ring-blue-600/50"
+									>
+										op.gg
+									</a>
 								</div>
 							</button>
 							<span className="text-sm text-center font-medium">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an op.gg quick-link button to each image tile’s overlay, alongside existing u.gg, blitz, and metasrc links.
  * Uses the champion/image name to route to the relevant op.gg page and opens in a new tab.
  * Matches the styling and interaction of existing link buttons for a consistent experience.
  * No changes to layout, sorting, or state—only the set of external links has been expanded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->